### PR TITLE
setup: use setuptools.setup to support bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from distutils.core import setup
+from setuptools import setup
 try:
     import pypandoc
     long_description = pypandoc.convert_file('README.md', 'rst')


### PR DESCRIPTION
Using the newer setuptools module the creation of a wheel package is possible using

```
python setup.py bdist_wheel
```